### PR TITLE
Add MultiPrintStream class for capturing output in many OutputStreams

### DIFF
--- a/src/main/kotlin/com/yonatankarp/kotlin/junit/tools/logger/MultiOutputStream.kt
+++ b/src/main/kotlin/com/yonatankarp/kotlin/junit/tools/logger/MultiOutputStream.kt
@@ -1,0 +1,52 @@
+package com.yonatankarp.kotlin.junit.tools.logger
+
+import java.io.Closeable
+import java.io.OutputStream
+import java.io.PrintStream
+
+/**
+ * A custom PrintStream that captures output to two different OutputStreams
+ * simultaneously.
+ *
+ * This class extends the PrintStream class and allows you to capture and
+ * duplicate the output that would normally be written to the 'originalOut'
+ * OutputStream to both the 'originalOut' and the 'captureOut' OutputStream.
+ *
+ * @param originalOut The original OutputStream to which the output is originally intended.
+ * @param captureOut The OutputStreams to capture and duplicate the output. You can specify multiple
+ * OutputStreams as varargs.
+ */
+class MultiOutputStream(originalOut: OutputStream, vararg captureOut: OutputStream): Closeable {
+
+    private val originalPrintStream = PrintStream(originalOut)
+    private val capturedStream = captureOut.map { PrintStream(it) }.toList()
+
+    /**
+     * Writes a single byte to both the 'originalOut' and 'captureOut' OutputStreams.
+     *
+     * @param body The byte to be written.
+     */
+    fun write(body: Int) {
+        originalPrintStream.write(body)
+        capturedStream.forEach { it.write(body) }
+    }
+
+    /**
+     * Writes a portion of an array of bytes to both the 'originalOut' and 'captureOut' OutputStreams.
+     *
+     * @param body The byte array.
+     * @param offset The start offset in the data.
+     */
+    fun write(body: ByteArray, offset: Int = 0) {
+        originalPrintStream.write(body, offset, body.size)
+        capturedStream.forEach { it.write(body, offset, body.size) }
+    }
+
+    /**
+     * Closes the DualPrintStream and all associated OutputStreams.
+     */
+    override fun close() {
+        originalPrintStream.close()
+        capturedStream.forEach { it.close() }
+    }
+}

--- a/src/test/kotlin/com/yonatankarp/kotlin/junit/tools/logger/MultiOutputStreamTest.kt
+++ b/src/test/kotlin/com/yonatankarp/kotlin/junit/tools/logger/MultiOutputStreamTest.kt
@@ -1,0 +1,47 @@
+package com.yonatankarp.kotlin.junit.tools.logger
+
+import java.io.ByteArrayOutputStream
+import kotlin.test.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+
+internal class MultiOutputStreamTest {
+    @Test
+    fun `test write single byte`() {
+        // Given
+        val originalOutputStream = ByteArrayOutputStream()
+        val captureOutputStream = ByteArrayOutputStream()
+        MultiOutputStream(originalOutputStream, captureOutputStream, System.out).use { dualPrintStream ->
+            // When
+            val byteToWrite = 'A'.code.toByte()
+            dualPrintStream.write(byteToWrite.toInt())
+
+            // Then
+            assertEquals(byteToWrite, originalOutputStream.toByteArray().first())
+            assertEquals(byteToWrite, captureOutputStream.toByteArray().first())
+        }
+    }
+
+    @Test
+    fun `test write nyte array`() {
+        // Given
+        val originalOutputStream = ByteArrayOutputStream()
+        val captureOutputStream = ByteArrayOutputStream()
+        MultiOutputStream(originalOutputStream, captureOutputStream, System.out).use { dualPrintStream ->
+            // When
+            val byteArrayToWrite = "Hello, World!".toByteArray()
+            dualPrintStream.write(byteArrayToWrite)
+
+            // Then
+            val originalOutputBytes = originalOutputStream.toByteArray()
+            val captureOutputBytes = captureOutputStream.toByteArray()
+
+            assertEquals(byteArrayToWrite.size, originalOutputBytes.size)
+            assertEquals(byteArrayToWrite.size, captureOutputBytes.size)
+
+            for (i in byteArrayToWrite.indices) {
+                assertEquals(byteArrayToWrite[i], originalOutputBytes[i])
+                assertEquals(byteArrayToWrite[i], captureOutputBytes[i])
+            }
+        }
+    }
+}


### PR DESCRIPTION

# Purpose

This commit introduces a new MultiPrintStream class, which allows the capturing and duplication of output to one or more specified OutputStreams simultaneously. The class provides a flexible way to capture output to various streams, enhancing logging and monitoring capabilities.

- The `MultiPrintStream` class accepts an original OutputStream and multiple capture OutputStreams as varargs.
- It provides methods to write both single bytes and byte arrays to all specified OutputStreams.
- The class implements the Closeable interface to ensure proper cleanup and closure of associated resources.

This addition improves the functionality of the project by enabling more versatile output handling.

# Types of changes

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

# Checklist

- [x] Documentation is updated
- [ ] No new tests are needed
