### PR TITLE
Fix release tag propagation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,4 +6,8 @@ on:
 
 jobs:
   artifact:
-    uses: yonatankarp/github-actions/.github/workflows/release.yml@v1
+    uses: yonatankarp/github-actions/.github/workflows/release.yml@fix_release_pipeline
+    with:
+      tag: ${GITHUB_REF#refs/*/}
+    secrets:
+      GITHUB_PATH: ${{ secrets.REVIEWER_GITHUB_TOKEN }}


### PR DESCRIPTION
# Purpose

This commit fixes the process of propagating the tag of the release to the pipeline and the PAT that is used to publish the jar into GitHub packages.

# Types of changes

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

# Checklist

- [ ] Documentation is updated
- [x] No new tests are needed
