### PR TITLE
Keep Dependabot style linting enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,3 @@ jobs:
 
   linters:
     uses: yonatankarp/github-actions/.github/workflows/linters.yml@v2
-    with:
-      check_style: false

--- a/src/main/kotlin/com/yonatankarp/kotlin/junit/tools/logger/InMemoryLoggerAppender.kt
+++ b/src/main/kotlin/com/yonatankarp/kotlin/junit/tools/logger/InMemoryLoggerAppender.kt
@@ -16,7 +16,9 @@ import org.slf4j.LoggerFactory
  * @param clazz The optional class for which to capture log events. If null, log
  * events will be captured for the root logger.
  */
-class InMemoryLoggerAppender(clazz: Class<*>? = null) : AppenderBase<ILoggingEvent>() {
+class InMemoryLoggerAppender(
+    clazz: Class<*>? = null,
+) : AppenderBase<ILoggingEvent>() {
     private val log = mutableListOf<ILoggingEvent>()
 
     init {

--- a/src/main/kotlin/com/yonatankarp/kotlin/junit/tools/logger/MultiOutputStream.kt
+++ b/src/main/kotlin/com/yonatankarp/kotlin/junit/tools/logger/MultiOutputStream.kt
@@ -16,8 +16,10 @@ import java.io.PrintStream
  * @param captureOut The OutputStreams to capture and duplicate the output. You can specify multiple
  * OutputStreams as varargs.
  */
-class MultiOutputStream(originalOut: OutputStream, vararg captureOut: OutputStream): Closeable {
-
+class MultiOutputStream(
+    originalOut: OutputStream,
+    vararg captureOut: OutputStream,
+) : Closeable {
     private val originalPrintStream = PrintStream(originalOut)
     private val capturedStream = captureOut.map { PrintStream(it) }.toList()
 
@@ -37,7 +39,10 @@ class MultiOutputStream(originalOut: OutputStream, vararg captureOut: OutputStre
      * @param body The byte array.
      * @param offset The start offset in the data.
      */
-    fun write(body: ByteArray, offset: Int = 0) {
+    fun write(
+        body: ByteArray,
+        offset: Int = 0,
+    ) {
         originalPrintStream.write(body, offset, body.size)
         capturedStream.forEach { it.write(body, offset, body.size) }
     }

--- a/src/test/kotlin/com/yonatankarp/kotlin/junit/tools/logger/InMemoryLoggerAppenderTest.kt
+++ b/src/test/kotlin/com/yonatankarp/kotlin/junit/tools/logger/InMemoryLoggerAppenderTest.kt
@@ -1,10 +1,10 @@
 package com.yonatankarp.kotlin.junit.tools.logger
 
+import ch.qos.logback.classic.Logger
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.slf4j.LoggerFactory
-import ch.qos.logback.classic.Logger
-import org.junit.jupiter.api.AfterEach
 import org.slf4j.event.Level.INFO
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -14,9 +14,10 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 internal class InMemoryLoggerAppenderTest {
-
-    private val logger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)
-        .apply { atLevel(INFO) }
+    private val logger =
+        LoggerFactory
+            .getLogger(Logger.ROOT_LOGGER_NAME)
+            .apply { atLevel(INFO) }
     private val appender = InMemoryLoggerAppender()
 
     @BeforeEach
@@ -71,10 +72,13 @@ internal class InMemoryLoggerAppenderTest {
 
     @Test
     fun `test init appender with class object catch only classes logs`() {
-        val instance = object {
-            val logger = LoggerFactory.getLogger(this::class.java)
-                .apply { atLevel(INFO) }
-        }
+        val instance =
+            object {
+                val logger =
+                    LoggerFactory
+                        .getLogger(this::class.java)
+                        .apply { atLevel(INFO) }
+            }
 
         val classAppender = InMemoryLoggerAppender(instance::class.java)
 

--- a/src/test/kotlin/com/yonatankarp/kotlin/junit/tools/logger/MultiOutputStreamTest.kt
+++ b/src/test/kotlin/com/yonatankarp/kotlin/junit/tools/logger/MultiOutputStreamTest.kt
@@ -1,8 +1,8 @@
 package com.yonatankarp.kotlin.junit.tools.logger
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import java.io.ByteArrayOutputStream
 import kotlin.test.Test
-import org.junit.jupiter.api.Assertions.assertEquals
 
 internal class MultiOutputStreamTest {
     @Test


### PR DESCRIPTION
Remove the temporary check_style override so the shared linter workflow remains responsible for deciding whether spotlessCheck is available.